### PR TITLE
Add XRESOURCES_RELOAD_PATCH

### DIFF
--- a/patch/xresources.c
+++ b/patch/xresources.c
@@ -34,15 +34,25 @@ resource_load(XrmDatabase db, char *name, enum resource_type rtype, void *dst)
 	return 0;
 }
 
+#if XRESOURCES_RELOAD_PATCH
+void
+config_init(Display *dpy)
+{
+#else
 void
 config_init(void)
 {
+#endif // XRESOURCES_RELOAD_PATCH
 	char *resm;
 	XrmDatabase db;
 	ResourcePref *p;
 
 	XrmInitialize();
+	#if XRESOURCES_RELOAD_PATCH
+	resm = XResourceManagerString(dpy);
+	#else
 	resm = XResourceManagerString(xw.dpy);
+	#endif // XRESOURCES_RELOAD_PATCH
 	if (!resm)
 		return;
 
@@ -50,3 +60,20 @@ config_init(void)
 	for (p = resources; p < resources + LEN(resources); p++)
 		resource_load(db, p->name, p->type, p->dst);
 }
+
+#if XRESOURCES_RELOAD_PATCH
+void reload_config(int sig){
+	/* Recreate a Display object to have up to date Xresources entries */
+	Display *dpy;
+	if (!(dpy = XOpenDisplay(NULL)))
+		die("Can't open display\n");
+
+	config_init(dpy);
+	if (sig != -1) {
+		/* Called due to a SIGUSR1 */
+		xloadcols();
+		redraw();
+	}
+	signal(SIGUSR1, reload_config);
+}
+#endif // XRESOURCES_RELOAD_PATCH

--- a/patch/xresources.h
+++ b/patch/xresources.h
@@ -14,4 +14,8 @@ typedef struct {
 } ResourcePref;
 
 int resource_load(XrmDatabase, char *, enum resource_type, void *);
+#if XRESOURCES_RELOAD_PATCH
+void config_init(Display *dpy);
+#else
 void config_init(void);
+#endif // XRESOURCES_RELOAD_PATCH

--- a/patches.def.h
+++ b/patches.def.h
@@ -292,3 +292,9 @@
  * https://st.suckless.org/patches/xresources/
  */
 #define XRESOURCES_PATCH 0
+
+/* This patch adds the ability to reload the Xresources config when a SIGUSR1 signal is received
+  e.g.: killall -USR1 st
+  Depends on the XRESOURCES_PATCH.
+ */
+#define XRESOURCES_RELOAD_PATCH 0

--- a/x.c
+++ b/x.c
@@ -2576,12 +2576,14 @@ run:
 
 	setlocale(LC_CTYPE, "");
 	XSetLocaleModifiers("");
-	#if XRESOURCES_PATCH
+	#if XRESOURCES_RELOAD_PATCH
+	reload_config(-1);
+	#elif XRESOURCES_PATCH
 	if (!(xw.dpy = XOpenDisplay(NULL)))
 		die("Can't open display\n");
 
 	config_init();
-	#endif // XRESOURCES_PATCH
+	#endif // XRESOURCES_RELOAD_PATCH
 	cols = MAX(cols, 1);
 	rows = MAX(rows, 1);
 	tnew(cols, rows);


### PR DESCRIPTION
Hi again,

For my setup, I want to change the color scheme on the fly, hence my previous escape sequence PR #15, I couldn't find a clean solution with escape sequences so I added a patch to get `st` to reload the Xresources to update the colorscheme, when it receives a `SIGUSR1` signal.

As far as I can tell it doesn't break anything, but please don't take my word for it 😀

Feel free to close this PR if you don't think this is useful.