### PR TITLE
XRESOURCES_PATCH with RELATIVEBORDER_PATCH

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -239,7 +239,11 @@ ResourcePref resources[] = {
 		{ "blinktimeout", INTEGER, &blinktimeout },
 		{ "bellvolume",   INTEGER, &bellvolume },
 		{ "tabspaces",    INTEGER, &tabspaces },
+		#if RELATIVEBORDER_PATCH
+		{ "borderperc",   INTEGER, &borderperc },
+		#else
 		{ "borderpx",     INTEGER, &borderpx },
+		#endif // RELATIVEBORDER_PATCH
 		{ "cwscale",      FLOAT,   &cwscale },
 		{ "chscale",      FLOAT,   &chscale },
 		#if ALPHA_PATCH


### PR DESCRIPTION
Hi,

The `RELATIVEBORDER_PATCH` isn't compatible with the `XRESOURCES_PATCH`, `borderpx` is undefined when `RELATIVEBORDER_PATCH` is active and should be replaced with `borderperc`. 