### PR TITLE
Advertise sixel support

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -37,7 +37,11 @@ char *scroll = NULL;
 char *stty_args = "stty raw pass8 nl -echo -iexten -cstopb 38400";
 
 /* identification sequence returned in DA and DECID */
+#if SIXEL_PATCH
+char *vtiden = "\033[?12;4c";
+#else
 char *vtiden = "\033[?6c";
+#endif
 
 /* Kerning / character bounding-box multipliers */
 static float cwscale = 1.0;


### PR DESCRIPTION
When the sixel patch is used, `st` should advertise it has sixel support by changing the `vtiden` variable.

For reference:
https://github.com/hackerb9/lsix/issues/32
https://github.com/charlesdaniels/st/issues/3