### PR TITLE
Fix white background bleeding through sixel images:

### DIFF
--- a/sixel.c
+++ b/sixel.c
@@ -252,7 +252,7 @@ sixel_parser_finalize(sixel_state_t *st, unsigned char *pixels)
 			*dst++ = color >> 16 & 0xff;   /* b */
 			*dst++ = color >> 8 & 0xff;    /* g */
 			*dst++ = color >> 0 & 0xff;    /* r */
-			dst++;                         /* a */
+			*dst++ = 255;                  /* a */
 		}
 		/* fill right padding with bgcolor */
 		for (; x < st->image.width; ++x) {


### PR DESCRIPTION
Tested with and without alpha patch applied. Simply setting alpha to 255 seems to fix it. I didn't set `dst` on lines 263 and 273 because those loops are impossible to reach.

Closes #13