### PR TITLE
scrollback: Don't scroll up when already at top

### DIFF
--- a/patch/scrollback.c
+++ b/patch/scrollback.c
@@ -33,7 +33,13 @@ kscrollup(const Arg* a)
 		tfulldirt();
 	}
 
-	#if SIXEL_PATCH
-	scroll_images(n);
-	#endif // SIXEL_PATCH
+	if (term.scr > term.histi) {
+		term.scr = term.histi;
+	}
+	else
+	{
+		#if SIXEL_PATCH
+		scroll_images(n);
+		#endif // SIXEL_PATCH
+	}
 }


### PR DESCRIPTION
If problems occur, a change in the macro definition (TLINE) or re-setting y-cursor position (term.c.y) might help.

There is a problem with SIXELs moving out of the visable area in some cases, but that might be a problem with the SIXEL scrolling code cause previously SIXELs already moved up after you scrolled for a while (e.g. when HISTSIZE is reached).