### PR TITLE
Add Solarized patch

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -161,7 +161,7 @@ float alphaUnfocused = 0.6;
 
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
-#ifdef SOLARIZED_DARK
+#if SOLARIZED_DARK
 	/* solarized dark */
 	"#073642",  /*  0: black    */
 	"#dc322f",  /*  1: red      */
@@ -179,6 +179,31 @@ static const char *colorname[] = {
 	"#6c71c4",  /* 13: brmagenta*/
 	"#93a1a1",  /* 14: brcyan   */
 	"#fdf6e3",  /* 15: brwhite  */
+#elif SOLARIZED_LIGHT
+	/* solarized light */
+	"#eee8d5",  /*  0: black    */
+	"#dc322f",  /*  1: red      */
+	"#859900",  /*  2: green    */
+	"#b58900",  /*  3: yellow   */
+	"#268bd2",  /*  4: blue     */
+	"#d33682",  /*  5: magenta  */
+	"#2aa198",  /*  6: cyan     */
+	"#073642",  /*  7: white    */
+	"#fdf6e3",  /*  8: brblack  */
+	"#cb4b16",  /*  9: brred    */
+	"#93a1a1",  /* 10: brgreen  */
+	"#839496",  /* 11: bryellow */
+	"#657b83",  /* 12: brblue   */
+	"#6c71c4",  /* 13: brmagenta*/
+	"#586e75",  /* 14: brcyan   */
+	"#002b36",  /* 15: brwhite  */
+	[255] = 0,
+
+	/* more colors can be added after 255 to use with DefaultXX */
+	"#add8e6", /* 256 -> cursor */
+	"#555555", /* 257 -> rev cursor*/
+	"#000000", /* 258 -> bg */
+	"#e5e5e5", /* 259 -> fg */
 #else
 	/* 8 normal colors */
 	"black",
@@ -207,7 +232,7 @@ static const char *colorname[] = {
 	"#555555", /* 257 -> rev cursor*/
 	"#000000", /* 258 -> bg */
 	"#e5e5e5", /* 259 -> fg */
-#endif // SOLARIZED_DARK
+#endif // SOLARIZED_DARK, SOLARIZED_LIGHT
 };
 
 
@@ -215,7 +240,7 @@ static const char *colorname[] = {
  * Default colors (colorname index)
  * foreground, background, cursor, reverse cursor
  */
-#if SOLARIZED_DARK
+#if SOLARIZED_DARK || SOLARIZED_LIGHT
 unsigned int defaultbg = 8;
 #elif ALPHA_PATCH && ALPHA_FOCUS_HIGHLIGHT_PATCH
 unsigned int defaultbg = 0;
@@ -224,7 +249,7 @@ unsigned int bg = 17, bgUnfocused = 16;
 unsigned int defaultbg = 258;
 #endif // SOLARIZED_DARK, ALPHA_FOCUS_HIGHLIGHT_PATCH
 
-#ifdef SOLARIZED_DARK
+#if SOLARIZED_DARK || SOLARIZED_LIGHT
 unsigned int defaultfg = 12;
 unsigned int defaultcs = 14;
 unsigned int defaultrcs = 15;

--- a/config.def.h
+++ b/config.def.h
@@ -161,6 +161,25 @@ float alphaUnfocused = 0.6;
 
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
+#ifdef SOLARIZED_DARK
+	/* solarized dark */
+	"#073642",  /*  0: black    */
+	"#dc322f",  /*  1: red      */
+	"#859900",  /*  2: green    */
+	"#b58900",  /*  3: yellow   */
+	"#268bd2",  /*  4: blue     */
+	"#d33682",  /*  5: magenta  */
+	"#2aa198",  /*  6: cyan     */
+	"#eee8d5",  /*  7: white    */
+	"#002b36",  /*  8: brblack  */
+	"#cb4b16",  /*  9: brred    */
+	"#586e75",  /* 10: brgreen  */
+	"#657b83",  /* 11: bryellow */
+	"#839496",  /* 12: brblue   */
+	"#6c71c4",  /* 13: brmagenta*/
+	"#93a1a1",  /* 14: brcyan   */
+	"#fdf6e3",  /* 15: brwhite  */
+#else
 	/* 8 normal colors */
 	"black",
 	"red3",
@@ -188,6 +207,7 @@ static const char *colorname[] = {
 	"#555555", /* 257 -> rev cursor*/
 	"#000000", /* 258 -> bg */
 	"#e5e5e5", /* 259 -> fg */
+#endif // SOLARIZED_DARK
 };
 
 
@@ -195,15 +215,24 @@ static const char *colorname[] = {
  * Default colors (colorname index)
  * foreground, background, cursor, reverse cursor
  */
-#if ALPHA_PATCH && ALPHA_FOCUS_HIGHLIGHT_PATCH
+#if SOLARIZED_DARK
+unsigned int defaultbg = 8;
+#elif ALPHA_PATCH && ALPHA_FOCUS_HIGHLIGHT_PATCH
 unsigned int defaultbg = 0;
 unsigned int bg = 17, bgUnfocused = 16;
 #else
 unsigned int defaultbg = 258;
-#endif // ALPHA_FOCUS_HIGHLIGHT_PATCH
+#endif // SOLARIZED_DARK, ALPHA_FOCUS_HIGHLIGHT_PATCH
+
+#ifdef SOLARIZED_DARK
+unsigned int defaultfg = 12;
+unsigned int defaultcs = 14;
+unsigned int defaultrcs = 15;
+#else
 unsigned int defaultfg = 259;
 unsigned int defaultcs = 256;
 unsigned int defaultrcs = 257;
+#endif // SOLARIZED_DARK
 
 #if VIM_BROWSE_PATCH
 unsigned int const currentBg = 6, buffSize = 2048;

--- a/config.def.h
+++ b/config.def.h
@@ -161,7 +161,7 @@ float alphaUnfocused = 0.6;
 
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
-#if SOLARIZED_DARK_PATCH
+#if SOLARIZED_DARK_PATCH || SOLARIZED_BOTH_PATCH
 	/* solarized dark */
 	"#073642",  /*  0: black    */
 	"#dc322f",  /*  1: red      */
@@ -232,24 +232,47 @@ static const char *colorname[] = {
 	"#555555", /* 257 -> rev cursor*/
 	"#000000", /* 258 -> bg */
 	"#e5e5e5", /* 259 -> fg */
-#endif // SOLARIZED_DARK_PATCH, SOLARIZED_LIGHT_PATCH
+#endif // SOLARIZED_[DARK|BOTH]_PATCH, SOLARIZED_LIGHT_PATCH
 };
+
+#if SOLARIZED_BOTH_PATCH
+/* Terminal colors for alternate (light) palette */
+static const char *altcolorname[] = {
+	/* solarized light */
+	"#eee8d5",  /*  0: black    */
+	"#dc322f",  /*  1: red      */
+	"#859900",  /*  2: green    */
+	"#b58900",  /*  3: yellow   */
+	"#268bd2",  /*  4: blue     */
+	"#d33682",  /*  5: magenta  */
+	"#2aa198",  /*  6: cyan     */
+	"#073642",  /*  7: white    */
+	"#fdf6e3",  /*  8: brblack  */
+	"#cb4b16",  /*  9: brred    */
+	"#93a1a1",  /* 10: brgreen  */
+	"#839496",  /* 11: bryellow */
+	"#657b83",  /* 12: brblue   */
+	"#6c71c4",  /* 13: brmagenta*/
+	"#586e75",  /* 14: brcyan   */
+	"#002b36",  /* 15: brwhite  */
+};
+#endif // SOLARIZED_BOTH_PATCH
 
 
 /*
  * Default colors (colorname index)
  * foreground, background, cursor, reverse cursor
  */
-#if SOLARIZED_DARK_PATCH || SOLARIZED_LIGHT_PATCH
+#if SOLARIZED_DARK_PATCH || SOLARIZED_LIGHT_PATCH || SOLARIZED_BOTH_PATCH
 unsigned int defaultbg = 8;
 #elif ALPHA_PATCH && ALPHA_FOCUS_HIGHLIGHT_PATCH
 unsigned int defaultbg = 0;
 unsigned int bg = 17, bgUnfocused = 16;
 #else
 unsigned int defaultbg = 258;
-#endif // SOLARIZED_DARK_PATCH, ALPHA_FOCUS_HIGHLIGHT_PATCH
+#endif // SOLARIZED_*_PATCH, ALPHA_FOCUS_HIGHLIGHT_PATCH
 
-#if SOLARIZED_DARK_PATCH || SOLARIZED_LIGHT_PATCH
+#if SOLARIZED_DARK_PATCH || SOLARIZED_LIGHT_PATCH || SOLARIZED_BOTH_PATCH
 unsigned int defaultfg = 12;
 unsigned int defaultcs = 14;
 unsigned int defaultrcs = 15;
@@ -257,7 +280,7 @@ unsigned int defaultrcs = 15;
 unsigned int defaultfg = 259;
 unsigned int defaultcs = 256;
 unsigned int defaultrcs = 257;
-#endif // SOLARIZED_DARK_PATCH
+#endif // SOLARIZED_*_PATCH
 
 #if VIM_BROWSE_PATCH
 unsigned int const currentBg = 6, buffSize = 2048;
@@ -466,6 +489,9 @@ static Shortcut shortcuts[] = {
 	{ ShiftMask,            XK_Insert,      selpaste,        {.i =  0} },
 	#endif // CLIPBOARD_PATCH
 	{ TERMMOD,              XK_Num_Lock,    numlock,         {.i =  0} },
+	#if SOLARIZED_BOTH_PATCH
+	{ XK_ANY_MOD,           XK_F6,          swapcolors,     {.i =  0} },
+	#endif
 	#if COPYURL_PATCH || COPYURL_HIGHLIGHT_SELECTED_URLS_PATCH
 	{ MODKEY,               XK_l,           copyurl,         {.i =  0} },
 	#endif // COPYURL_PATCH

--- a/config.def.h
+++ b/config.def.h
@@ -161,7 +161,7 @@ float alphaUnfocused = 0.6;
 
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
-#if SOLARIZED_DARK
+#if SOLARIZED_DARK_PATCH
 	/* solarized dark */
 	"#073642",  /*  0: black    */
 	"#dc322f",  /*  1: red      */
@@ -179,7 +179,7 @@ static const char *colorname[] = {
 	"#6c71c4",  /* 13: brmagenta*/
 	"#93a1a1",  /* 14: brcyan   */
 	"#fdf6e3",  /* 15: brwhite  */
-#elif SOLARIZED_LIGHT
+#elif SOLARIZED_LIGHT_PATCH
 	/* solarized light */
 	"#eee8d5",  /*  0: black    */
 	"#dc322f",  /*  1: red      */
@@ -232,7 +232,7 @@ static const char *colorname[] = {
 	"#555555", /* 257 -> rev cursor*/
 	"#000000", /* 258 -> bg */
 	"#e5e5e5", /* 259 -> fg */
-#endif // SOLARIZED_DARK, SOLARIZED_LIGHT
+#endif // SOLARIZED_DARK_PATCH, SOLARIZED_LIGHT_PATCH
 };
 
 
@@ -240,16 +240,16 @@ static const char *colorname[] = {
  * Default colors (colorname index)
  * foreground, background, cursor, reverse cursor
  */
-#if SOLARIZED_DARK || SOLARIZED_LIGHT
+#if SOLARIZED_DARK_PATCH || SOLARIZED_LIGHT_PATCH
 unsigned int defaultbg = 8;
 #elif ALPHA_PATCH && ALPHA_FOCUS_HIGHLIGHT_PATCH
 unsigned int defaultbg = 0;
 unsigned int bg = 17, bgUnfocused = 16;
 #else
 unsigned int defaultbg = 258;
-#endif // SOLARIZED_DARK, ALPHA_FOCUS_HIGHLIGHT_PATCH
+#endif // SOLARIZED_DARK_PATCH, ALPHA_FOCUS_HIGHLIGHT_PATCH
 
-#if SOLARIZED_DARK || SOLARIZED_LIGHT
+#if SOLARIZED_DARK_PATCH || SOLARIZED_LIGHT_PATCH
 unsigned int defaultfg = 12;
 unsigned int defaultcs = 14;
 unsigned int defaultrcs = 15;
@@ -257,7 +257,7 @@ unsigned int defaultrcs = 15;
 unsigned int defaultfg = 259;
 unsigned int defaultcs = 256;
 unsigned int defaultrcs = 257;
-#endif // SOLARIZED_DARK
+#endif // SOLARIZED_DARK_PATCH
 
 #if VIM_BROWSE_PATCH
 unsigned int const currentBg = 6, buffSize = 2048;

--- a/patches.def.h
+++ b/patches.def.h
@@ -308,6 +308,8 @@
  */
 #define SIXEL_PATCH 0
 
+#define SOLARIZED_DARK 0
+
 /* This patch allows clients to embed into the st window and is useful if you tend to
  * start X applications from the terminal. For example:
  *

--- a/patches.def.h
+++ b/patches.def.h
@@ -318,7 +318,7 @@
  * Schoonover. Note that this patch will override ALPHA_FOCUS_HIGHLIGHT_PATCH
  * http://st.suckless.org/patches/solarized/
  */
-#define SOLARIZED_LIGHT 1
+#define SOLARIZED_LIGHT 0
 
 /* This patch allows clients to embed into the st window and is useful if you tend to
  * start X applications from the terminal. For example:

--- a/patches.def.h
+++ b/patches.def.h
@@ -312,13 +312,13 @@
  * Schoonover. Note that this patch will override ALPHA_FOCUS_HIGHLIGHT_PATCH
  * http://st.suckless.org/patches/solarized/
  */
-#define SOLARIZED_DARK 0
+#define SOLARIZED_DARK_PATCH 0
 
 /* This patch sets the color scheme to the solarized light scheme by Ethan
  * Schoonover. Note that this patch will override ALPHA_FOCUS_HIGHLIGHT_PATCH
  * http://st.suckless.org/patches/solarized/
  */
-#define SOLARIZED_LIGHT 0
+#define SOLARIZED_LIGHT_PATCH 0
 
 /* This patch allows clients to embed into the st window and is useful if you tend to
  * start X applications from the terminal. For example:

--- a/patches.def.h
+++ b/patches.def.h
@@ -308,8 +308,16 @@
  */
 #define SIXEL_PATCH 0
 
+/* This patch sets the color scheme to the solarized dark & light scheme by
+ * Ethan Schoonover. Note that this patch will override
+ * ALPHA_FOCUS_HIGHLIGHT_PATCH and SOLARIZED_LIGHT_PATCH
+ * http://st.suckless.org/patches/solarized/
+ */
+#define SOLARIZED_BOTH_PATCH 0
+
 /* This patch sets the color scheme to the solarized dark scheme by Ethan
  * Schoonover. Note that this patch will override ALPHA_FOCUS_HIGHLIGHT_PATCH
+ * and SOLARIZED_LIGHT_PATCH
  * http://st.suckless.org/patches/solarized/
  */
 #define SOLARIZED_DARK_PATCH 0

--- a/patches.def.h
+++ b/patches.def.h
@@ -314,6 +314,12 @@
  */
 #define SOLARIZED_DARK 0
 
+/* This patch sets the color scheme to the solarized light scheme by Ethan
+ * Schoonover. Note that this patch will override ALPHA_FOCUS_HIGHLIGHT_PATCH
+ * http://st.suckless.org/patches/solarized/
+ */
+#define SOLARIZED_LIGHT 1
+
 /* This patch allows clients to embed into the st window and is useful if you tend to
  * start X applications from the terminal. For example:
  *

--- a/patches.def.h
+++ b/patches.def.h
@@ -308,6 +308,10 @@
  */
 #define SIXEL_PATCH 0
 
+/* This patch sets the color scheme to the solarized dark scheme by Ethan
+ * Schoonover. Note that this patch will override ALPHA_FOCUS_HIGHLIGHT_PATCH
+ * http://st.suckless.org/patches/solarized/
+ */
 #define SOLARIZED_DARK 0
 
 /* This patch allows clients to embed into the st window and is useful if you tend to

--- a/st.h
+++ b/st.h
@@ -353,6 +353,9 @@ extern wchar_t *worddelimiters;
 extern int allowaltscreen;
 extern int allowwindowops;
 extern char *termname;
+#if SOLARIZED_BOTH_PATCH
+extern int usealtcolors;
+#endif // SOLARIZED_BOTH_PATCH
 extern unsigned int tabspaces;
 extern unsigned int defaultfg;
 extern unsigned int defaultbg;


### PR DESCRIPTION
I've taken the liberty of adding in the conditions for the three different [solarized patches](http://st.suckless.org/patches/solarized/) (dark, light, and both). There does seem to be some overlap with `ALPHA_FOCUS_HIGHLIGHT_PATCH` regarding the `defaultbg` value. Shouldn't be an issue so long as the user doesn't want both at once.