### PR TITLE
Fix border issues in the anysize patch

### DIFF
--- a/x.c
+++ b/x.c
@@ -1924,7 +1924,7 @@ xdrawglyphfontspecs(const XftGlyphFontSpec *specs, Glyph base, int len, int x, i
 	/* Intelligent cleaning up of the borders. */
 	#if ANYSIZE_PATCH
 	if (x == 0) {
-		xclear(0, (y == 0)? 0 : winy, win.vborderpx,
+		xclear(0, (y == 0)? 0 : winy, win.hborderpx,
 			winy + win.ch +
 			((winy + win.ch >= win.vborderpx + win.th)? win.h : 0));
 	}
@@ -1933,7 +1933,7 @@ xdrawglyphfontspecs(const XftGlyphFontSpec *specs, Glyph base, int len, int x, i
 			((winy + win.ch >= win.vborderpx + win.th)? win.h : (winy + win.ch)));
 	}
 	if (y == 0)
-		xclear(winx, 0, winx + width, win.hborderpx);
+		xclear(winx, 0, winx + width, win.vborderpx);
 	if (winy + win.ch >= win.vborderpx + win.th)
 		xclear(winx, winy + win.ch, winx + width, win.h);
 	#else


### PR DESCRIPTION
I found two bugs in the anysize patch which can leave stripes on the borders when the patch is trying to clear them. So, for example, if you are using theme.sh to change the theme, these issues may occur and for that reason the anysize-nobar is designed to fix them. Unfortunately, that patch isn't attempting to fix the original problem but trying to circumvent it by doing some questionable things. But after this fix, the anysize-nobar patch shouldn't be needed anymore and could be removed unless it's doing something else I'm not aware of.

Here is some detailed info about the bugs:

**The definition of xclear function**

```
xclear(int x1, int y1, int x2, int y2)
```

**The first bug**

```
   if (x == 0) {
       xclear(0, (y == 0)? 0 : winy, win.vborderpx,
           winy + win.ch +
           ((winy + win.ch >= win.vborderpx + win.th)? win.h : 0));
   }
```

Because the third parameter of xclear is x2, win.vborderpx should be win.hborderpx (horizontal border) and the line should be:

```
   if (x == 0) {
       xclear(0, (y == 0)? 0 : winy, win.hborderpx,
           winy + win.ch +
           ((winy + win.ch >= win.vborderpx + win.th)? win.h : 0));
   }
```

**The second bug**

```
    if (y == 0)
        xclear(winx, 0, winx + width, win.hborderpx);
```

Because the fourth parameter of xclear is y2, win.hborderpx should be win.vborderpx (vertical border) and the line should be:

```
    if (y == 0)
        xclear(winx, 0, winx + width, win.vborderpx);
```

These fixes should be pushed to the upstream too, but unfortunately I haven't joined the suckless mailing list yet, so I'm unable to do so.