### PR TITLE
Extend fullscreen patch

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -402,8 +402,8 @@ static Shortcut shortcuts[] = {
 	#endif // ALPHA_FOCUS_HIGHLIGHT_PATCH
 	#endif // ALPHA_PATCH
 	#if FULLSCREEN_PATCH
-	{ XK_NO_MOD,            XK_F11,         fullscreen,      {.i =  0} },
-	{ MODKEY,               XK_Return,      fullscreen,      {.i =  0} },
+	{ XK_NO_MOD,            XK_F11,         toggle_fullscreen,      {.i =  0} },
+	{ MODKEY,               XK_Return,      toggle_fullscreen,      {.i =  0} },
 	#endif // FULLSCREEN_PATCH
 	#if SCROLLBACK_PATCH
 	{ ShiftMask,            XK_Page_Up,     kscrollup,       {.i = -1}, S_PRI },

--- a/patch/fullscreen_x.c
+++ b/patch/fullscreen_x.c
@@ -1,17 +1,32 @@
-void
-fullscreen(const Arg *arg)
+void set_fullscreen_status(int status)
 {
-	XEvent ev;
+    XEvent ev;
 
-	memset(&ev, 0, sizeof(ev));
+    memset(&ev, 0, sizeof(ev));
 
-	ev.xclient.type = ClientMessage;
-	ev.xclient.message_type = xw.netwmstate;
-	ev.xclient.display = xw.dpy;
-	ev.xclient.window = xw.win;
-	ev.xclient.format = 32;
-	ev.xclient.data.l[0] = 2; /* _NET_WM_STATE_TOGGLE */
-	ev.xclient.data.l[1] = xw.netwmfullscreen;
+    ev.xclient.type         = ClientMessage;
+    ev.xclient.message_type = xw.netwmstate;
+    ev.xclient.display      = xw.dpy;
+    ev.xclient.window       = xw.win;
+    ev.xclient.format       = 32;
+    ev.xclient.data.l[0]    = status;
+    ev.xclient.data.l[1]    = xw.netwmfullscreen;
 
-	XSendEvent(xw.dpy, DefaultRootWindow(xw.dpy), False, SubstructureNotifyMask|SubstructureRedirectMask, &ev);
+    XSendEvent(xw.dpy, DefaultRootWindow(xw.dpy), False, SubstructureNotifyMask | SubstructureRedirectMask, &ev);
 }
+
+void set_fullscreen(void)
+{
+    set_fullscreen_status(1);
+}
+
+void unset_fullscreen(void)
+{
+    set_fullscreen_status(0);
+}
+
+void toggle_fullscreen(const Arg* arg)
+{
+    set_fullscreen_status(2);
+}
+

--- a/patch/fullscreen_x.c
+++ b/patch/fullscreen_x.c
@@ -1,32 +1,36 @@
-void set_fullscreen_status(int status)
+void
+set_fullscreen_status(int status)
 {
-    XEvent ev;
+	XEvent ev;
 
-    memset(&ev, 0, sizeof(ev));
+	memset(&ev, 0, sizeof(ev));
 
-    ev.xclient.type         = ClientMessage;
-    ev.xclient.message_type = xw.netwmstate;
-    ev.xclient.display      = xw.dpy;
-    ev.xclient.window       = xw.win;
-    ev.xclient.format       = 32;
-    ev.xclient.data.l[0]    = status;
-    ev.xclient.data.l[1]    = xw.netwmfullscreen;
+	ev.xclient.type = ClientMessage;
+	ev.xclient.message_type = xw.netwmstate;
+	ev.xclient.display = xw.dpy;
+	ev.xclient.window = xw.win;
+	ev.xclient.format = 32;
+	ev.xclient.data.l[0] = status;
+	ev.xclient.data.l[1] = xw.netwmfullscreen;
 
-    XSendEvent(xw.dpy, DefaultRootWindow(xw.dpy), False, SubstructureNotifyMask | SubstructureRedirectMask, &ev);
+	XSendEvent(xw.dpy, DefaultRootWindow(xw.dpy), False, SubstructureNotifyMask | SubstructureRedirectMask, &ev);
 }
 
-void set_fullscreen(void)
+void
+set_fullscreen(void)
 {
-    set_fullscreen_status(1);
+	set_fullscreen_status(1);
 }
 
-void unset_fullscreen(void)
+void
+unset_fullscreen(void)
 {
-    set_fullscreen_status(0);
+	set_fullscreen_status(0);
 }
 
-void toggle_fullscreen(const Arg* arg)
+void
+toggle_fullscreen(const Arg* arg)
 {
-    set_fullscreen_status(2);
+	set_fullscreen_status(2);
 }
 

--- a/patch/fullscreen_x.h
+++ b/patch/fullscreen_x.h
@@ -1,1 +1,4 @@
-static void fullscreen(const Arg *arg);
+void set_fullscreen();
+void unset_fullscreen();
+void toggle_fullscreen(const Arg*);
+void sigusr2_fullscreen(int sig);

--- a/patch/fullscreen_x.h
+++ b/patch/fullscreen_x.h
@@ -1,4 +1,4 @@
-void set_fullscreen();
-void unset_fullscreen();
+void set_fullscreen(void);
+void unset_fullscreen(void);
 void toggle_fullscreen(const Arg*);
 void sigusr2_fullscreen(int sig);

--- a/x.c
+++ b/x.c
@@ -757,8 +757,8 @@ sigusr1_reload(int sig)
 
 #if FULLSCREEN_PATCH
 void sigusr2_fullscreen(int sig) {
-    set_fullscreen();
-    signal(SIGUSR2, sigusr2_fullscreen);
+	set_fullscreen();
+	signal(SIGUSR2, sigusr2_fullscreen);
 }
 #endif // FULLSCREEN_PATCH
 
@@ -3424,9 +3424,9 @@ usage(void)
 		#if WORKINGDIR_PATCH
 		" [-d path]"
 		#endif // WORKINGDIR_PATCH
-        #if FULLSCREEN_PATCH
-        " [-F]",
-        #endif // FULLSCREEN_PATCH
+	    #if FULLSCREEN_PATCH
+	    " [-F]",
+	    #endif // FULLSCREEN_PATCH
 		" [-f font] [-g geometry]"
 	    " [-n name] [-o file]\n"
 	    "          [-T title] [-t title] [-w windowid] -l line"
@@ -3461,11 +3461,11 @@ main(int argc, char *argv[])
 		opt_dir = EARGF(usage());
 		break;
 	#endif // WORKINGDIR_PATCH
-    #if FULLSCREEN_PATCH
-    case 'F':
-        opt_fullscreen = 1;
-        break;
-    #endif // FULLSCREEN_PATCH
+	#if FULLSCREEN_PATCH
+	case 'F':
+		opt_fullscreen = 1;
+		break;
+	#endif // FULLSCREEN_PATCH
 	case 'e':
 		if (argc > 0)
 			--argc, ++argv;
@@ -3522,9 +3522,9 @@ run:
 	config_init(xw.dpy);
 	#endif // XRESOURCES_PATCH
 
-    #if FULLSCREEN_PATCH
-        signal(SIGUSR2, sigusr2_fullscreen);
-    #endif // FULLSCREEN_PATCH
+	#if FULLSCREEN_PATCH
+		signal(SIGUSR2, sigusr2_fullscreen);
+	#endif // FULLSCREEN_PATCH
 
 	cols = MAX(cols, 1);
 	rows = MAX(rows, 1);
@@ -3543,10 +3543,10 @@ run:
 		die("Can't change to working directory %s\n", opt_dir);
 	#endif // WORKINGDIR_PATCH
 
-    #if FULLSCREEN_PATCH
-    if (opt_fullscreen)
-        set_fullscreen();
-    #endif // FULLSCREEN_PATCH
+	#if FULLSCREEN_PATCH
+	if (opt_fullscreen)
+		set_fullscreen();
+	#endif // FULLSCREEN_PATCH
 
 	run();
 

--- a/x.c
+++ b/x.c
@@ -755,6 +755,13 @@ sigusr1_reload(int sig)
 }
 #endif // XRESOURCES_RELOAD_PATCH | BACKGROUND_IMAGE_RELOAD_PATCH
 
+#if FULLSCREEN_PATCH
+void sigusr2_fullscreen(int sig) {
+    set_fullscreen();
+    signal(SIGUSR2, sigusr2_fullscreen);
+}
+#endif // FULLSCREEN_PATCH
+
 void
 xsetsel(char *str)
 {
@@ -3514,6 +3521,11 @@ run:
 
 	config_init(xw.dpy);
 	#endif // XRESOURCES_PATCH
+
+    #if FULLSCREEN_PATCH
+        signal(SIGUSR2, sigusr2_fullscreen);
+    #endif // FULLSCREEN_PATCH
+
 	cols = MAX(cols, 1);
 	rows = MAX(rows, 1);
 	#if ALPHA_PATCH && ALPHA_FOCUS_HIGHLIGHT_PATCH

--- a/x.c
+++ b/x.c
@@ -3545,7 +3545,7 @@ run:
 
     #if FULLSCREEN_PATCH
     if (opt_fullscreen)
-        set_fullscreen(NULL);
+        set_fullscreen();
     #endif // FULLSCREEN_PATCH
 
 	run();

--- a/x.c
+++ b/x.c
@@ -3424,9 +3424,9 @@ usage(void)
 		#if WORKINGDIR_PATCH
 		" [-d path]"
 		#endif // WORKINGDIR_PATCH
-	    #if FULLSCREEN_PATCH
-	    " [-F]",
-	    #endif // FULLSCREEN_PATCH
+		#if FULLSCREEN_PATCH
+		" [-F]",
+		#endif // FULLSCREEN_PATCH
 		" [-f font] [-g geometry]"
 	    " [-n name] [-o file]\n"
 	    "          [-T title] [-t title] [-w windowid] -l line"

--- a/x.c
+++ b/x.c
@@ -207,6 +207,9 @@ static char *opt_title = NULL;
 #if WORKINGDIR_PATCH
 static char *opt_dir   = NULL;
 #endif // WORKINGDIR_PATCH
+#if FULLSCREEN_PATCH
+static int opt_fullscreen = 0;
+#endif // FULLSCREEN_PATCH
 
 #if ALPHA_PATCH && ALPHA_FOCUS_HIGHLIGHT_PATCH
 static int focused = 0;
@@ -3414,6 +3417,9 @@ usage(void)
 		#if WORKINGDIR_PATCH
 		" [-d path]"
 		#endif // WORKINGDIR_PATCH
+        #if FULLSCREEN_PATCH
+        " [-F]",
+        #endif // FULLSCREEN_PATCH
 		" [-f font] [-g geometry]"
 	    " [-n name] [-o file]\n"
 	    "          [-T title] [-t title] [-w windowid] -l line"
@@ -3448,6 +3454,11 @@ main(int argc, char *argv[])
 		opt_dir = EARGF(usage());
 		break;
 	#endif // WORKINGDIR_PATCH
+    #if FULLSCREEN_PATCH
+    case 'F':
+        opt_fullscreen = 1;
+        break;
+    #endif // FULLSCREEN_PATCH
 	case 'e':
 		if (argc > 0)
 			--argc, ++argv;
@@ -3519,6 +3530,12 @@ run:
 	if (opt_dir && chdir(opt_dir))
 		die("Can't change to working directory %s\n", opt_dir);
 	#endif // WORKINGDIR_PATCH
+
+    #if FULLSCREEN_PATCH
+    if (opt_fullscreen)
+        set_fullscreen(NULL);
+    #endif // FULLSCREEN_PATCH
+
 	run();
 
 	return 0;


### PR DESCRIPTION
Extend fullscreen patch:
- Add `set_fullscreen`, `unset_fullscreen` and `toggle_fullscreen` functions
- Add -F parameter to start st in fullscreen mode
- Add handler to set fullscreen mode on USR2 signal:
Useful in some cases like when hiding and restoring the window do not
respect the full screen state. May be too specific.




