### PR TITLE
Check for already exisiting desktop entry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ install: st
 	chmod 644 $(DESTDIR)$(MANPREFIX)/man1/st.1
 	tic -sx st.info
 	mkdir -p $(DESTDIR)$(PREFIX)/share/applications # desktop-entry patch
-	cp -n st.desktop $(DESTDIR)$(PREFIX)/share/applications # desktop-entry patch
+	test -f ${DESTDIR}${PREFIX}/share/applications/st.desktop || cp -n st.desktop $(DESTDIR)$(PREFIX)/share/applications # desktop-entry patch
 	@echo Please see the README file regarding the terminfo entry of st.
 
 uninstall:


### PR DESCRIPTION
When st desktop entry already exists it throws error when running make