### PR TITLE
use NETWMICON-0.8.5-v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,13 @@ install: st
 	mkdir -p $(DESTDIR)$(PREFIX)/share/applications # desktop-entry patch
 	test -f ${DESTDIR}${PREFIX}/share/applications/st.desktop || cp -n st.desktop $(DESTDIR)$(PREFIX)/share/applications # desktop-entry patch
 	@echo Please see the README file regarding the terminfo entry of st.
+	mkdir -p $(DESTDIR)$(ICONPREFIX) # netwmicon patch
+	[ -f $(ICONNAME) ] && cp -f $(ICONNAME) $(DESTDIR)$(ICONPREFIX) || :
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/st
 	rm -f $(DESTDIR)$(MANPREFIX)/man1/st.1
 	rm -f $(DESTDIR)$(PREFIX)/share/applications/st.desktop # desktop-entry patch
+	rm -f $(DESTDIR)$(ICONPREFIX)/$(ICONNAME) # netwmicon patch
 
 .PHONY: all options clean dist install uninstall

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Refer to [https://st.suckless.org/](https://st.suckless.org/) for details on the
       - makes st ignore terminal color attributes to make for a monochrome look
 
    - [netwmicon](https://st.suckless.org/patches/netwmicon/)
-      - this patch sets the \_NET\_WM\_ICON X property with a hardcoded icon for st
+      - this patch sets the \_NET\_WM\_ICON X property with png file on /usr/local/share/st.icon
 
    - [newterm](https://st.suckless.org/patches/newterm/)
       - allows you to spawn a new st terminal using Ctrl-Shift-Return

--- a/config.mk
+++ b/config.mk
@@ -6,7 +6,8 @@ VERSION = 0.9
 # paths
 PREFIX = /usr/local
 MANPREFIX = $(PREFIX)/share/man
-
+ICONPREFIX = $(PREFIX)/share/pixmaps
+ICONNAME = st.png
 X11INC = /usr/X11R6/include
 X11LIB = /usr/X11R6/lib
 
@@ -27,18 +28,21 @@ PKG_CONFIG = pkg-config
 # Uncomment this for the SIXEL patch / SIXEL_PATCH
 #SIXEL_C = sixel.c sixel_hls.c
 
+#Uncomment this for the WMNETICON_PATCH
+#LGD = -lgd
+
 # includes and libs, uncomment harfbuzz for the ligatures patch
 INCS = -I$(X11INC) \
        `$(PKG_CONFIG) --cflags fontconfig` \
        `$(PKG_CONFIG) --cflags freetype2` \
        $(LIGATURES_INC)
-LIBS = -L$(X11LIB) -lm -lrt -lX11 -lutil -lXft ${XRENDER} ${XCURSOR}\
+LIBS = -L$(X11LIB) -lm -lrt -lX11 -lutil -lXft ${LGD} ${XRENDER} ${XCURSOR}\
        `$(PKG_CONFIG) --libs fontconfig` \
        `$(PKG_CONFIG) --libs freetype2` \
        $(LIGATURES_LIBS)
 
 # flags
-STCPPFLAGS = -DVERSION=\"$(VERSION)\" -D_XOPEN_SOURCE=600
+STCPPFLAGS = -DVERSION=\"$(VERSION)\" -DICON=\"$(ICONPREFIX)/$(ICONNAME)\" -D_XOPEN_SOURCE=600
 STCFLAGS = $(INCS) $(STCPPFLAGS) $(CPPFLAGS) $(CFLAGS)
 STLDFLAGS = $(LIBS) $(LDFLAGS)
 

--- a/patch/x_include.h
+++ b/patch/x_include.h
@@ -24,7 +24,7 @@
 #include "keyboardselect_x.h"
 #endif
 #if NETWMICON_PATCH
-#include "netwmicon.h"
+#include <gd.h>
 #endif
 #if RIGHTCLICKTOPLUMB_PATCH
 #include "rightclicktoplumb_x.h"


### PR DESCRIPTION
on  2022-06-04, the patch was updated, but this repo added the patch on 2021-05-08 and not updated it since it, this pull request use the updated code of the patch that uses a png file (/usr/local/share/st.png), this way is better than the hardcoded icon