### PR TITLE
Remove black bars from sixel images

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -59,6 +59,11 @@ char *vtiden = "\033[?12;4c";
 char *vtiden = "\033[?6c";
 #endif
 
+/* remove black bars from sixel images */
+#if SIXEL_PATCH
+int const sixelremovebars = 1;
+#endif // SIXEL_PATCH
+
 /* Kerning / character bounding-box multipliers */
 static float cwscale = 1.0;
 static float chscale = 1.0;

--- a/st.c
+++ b/st.c
@@ -2652,14 +2652,15 @@ strhandle(void)
 			memset(new_image, 0, sizeof(ImageList));
 			new_image->x = term.c.x;
 			new_image->y = term.c.y;
-			new_image->width = sixel_st.image.width;
-			new_image->height = sixel_st.image.height;
-			new_image->pixels = malloc(new_image->width * new_image->height * 4);
+			new_image->pixels = malloc(sixel_st.image.width * sixel_st.image.height * 4);
 			if (sixel_parser_finalize(&sixel_st, new_image->pixels) != 0) {
 				perror("sixel_parser_finalize() failed");
 				sixel_parser_deinit(&sixel_st);
 				return;
 			}
+			/* set width and height here because sixel_parser_finalize() above can change them */
+			new_image->width = sixel_st.image.width;
+			new_image->height = sixel_st.image.height;
 			sixel_parser_deinit(&sixel_st);
 			if (term.images) {
 				ImageList *im;


### PR DESCRIPTION
When the images don't fully cover the text cells, black bars are added to them. This fix removes those bars, but if you need the old behavior, you can restore it by setting 'sixelremovebars' to zero in config.h

Ref. https://github.com/bakkeby/st-flexipatch/issues/102#issuecomment-1719963168