### PR TITLE
Remove black bars from sixel images and add...

### DIFF
--- a/patch/sixel_st.c
+++ b/patch/sixel_st.c
@@ -3,6 +3,9 @@ sixel_state_t sixel_st;
 void
 dcshandle(void)
 {
+	int bgcolor;
+	unsigned char r, g, b, a = 255;
+
 	switch (csiescseq.mode[0]) {
 	default:
 		fprintf(stderr, "erresc: unknown csi ");
@@ -10,7 +13,19 @@ dcshandle(void)
 		/* die(""); */
 		break;
 	case 'q': /* DECSIXEL */
-		if (sixel_parser_init(&sixel_st, 0, 0 << 16 | 0 << 8 | 0, 1, win.cw, win.ch) != 0)
+		if (IS_TRUECOL(term.c.attr.bg)) {
+			r = term.c.attr.bg >> 16 & 255;
+			g = term.c.attr.bg >> 8 & 255;
+			b = term.c.attr.bg >> 0 & 255;
+		} else {
+			xgetcolor(term.c.attr.bg, &r, &g, &b);
+			#if ALPHA_PATCH
+			if (term.c.attr.bg == defaultbg)
+				a = dc.col[defaultbg].pixel >> 24 & 255;
+			#endif // ALPHA_PATCH
+		}
+		bgcolor = a << 24 | b << 16 | g << 8 | r;
+		if (sixel_parser_init(&sixel_st, 255 << 24, bgcolor, 1, win.cw, win.ch) != 0)
 			perror("sixel_parser_init() failed");
 		term.mode |= MODE_SIXEL;
 		break;

--- a/sixel.c
+++ b/sixel.c
@@ -8,7 +8,7 @@
 #include "sixel.h"
 #include "sixel_hls.h"
 
-#define SIXEL_RGB(r, g, b) ((r) + ((g) << 8) +  ((b) << 16))
+#define SIXEL_RGB(r, g, b) ((r) + ((g) << 8) + ((b) << 16) + (255 << 24))
 #define SIXEL_PALVAL(n,a,m) (((n) * (a) + ((m) / 2)) / (m))
 #define SIXEL_XRGB(r,g,b) SIXEL_RGB(SIXEL_PALVAL(r, 255, 100), SIXEL_PALVAL(g, 255, 100), SIXEL_PALVAL(b, 255, 100))
 
@@ -252,7 +252,7 @@ sixel_parser_finalize(sixel_state_t *st, unsigned char *pixels)
 			*dst++ = color >> 16 & 0xff;   /* b */
 			*dst++ = color >> 8 & 0xff;    /* g */
 			*dst++ = color >> 0 & 0xff;    /* r */
-			*dst++ = 255;                  /* a */
+			*dst++ = color >> 24 & 0xff;   /* a */
 		}
 		/* fill right padding with bgcolor */
 		for (; x < st->image.width; ++x) {
@@ -260,7 +260,7 @@ sixel_parser_finalize(sixel_state_t *st, unsigned char *pixels)
 			*dst++ = color >> 16 & 0xff;   /* b */
 			*dst++ = color >> 8 & 0xff;    /* g */
 			*dst++ = color >> 0 & 0xff;    /* r */
-			dst++;                         /* a */
+			*dst++ = color >> 24 & 0xff;   /* a */
 		}
 	}
 	/* fill bottom padding with bgcolor */
@@ -270,7 +270,7 @@ sixel_parser_finalize(sixel_state_t *st, unsigned char *pixels)
 			*dst++ = color >> 16 & 0xff;   /* b */
 			*dst++ = color >> 8 & 0xff;    /* g */
 			*dst++ = color >> 0 & 0xff;    /* r */
-			dst++;                         /* a */
+			*dst++ = color >> 24 & 0xff;   /* a */
 		}
 	}
 

--- a/sixel_hls.c
+++ b/sixel_hls.c
@@ -30,7 +30,7 @@
 // sale, use or other dealings in this Software without prior written
 // authorization.
 
-#define SIXEL_RGB(r, g, b) (((r) << 16) + ((g) << 8) +  (b))
+#define SIXEL_RGB(r, g, b) ((r) + ((g) << 8) + ((b) << 16) + (255 << 24))
 
 int
 hls_to_rgb(int hue, int lum, int sat)


### PR DESCRIPTION
...support for transparency. Technically, the sixels do not have transparency, but empty pixels are now rendered with the current background color instead of black to make the them appear transparent. Same goes for the black bars. The current background color makes them disappear.

Before
![before](https://github.com/bakkeby/st-flexipatch/assets/106755522/c909668b-b474-4a1e-8ea9-6cffabf6bcd3)

After
![after](https://github.com/bakkeby/st-flexipatch/assets/106755522/3694ba06-d45f-424d-833a-d3d20af0adc9)

There is one technical limitation with the alpha focus highlight patch. The alpha value and background color is taken from the current background color, so when the window is unfocused, images may have the wrong alpha and/or background color. This can't be fixed easily.

Ref. https://github.com/bakkeby/st-flexipatch/issues/102#issuecomment-1719963168