### PR TITLE
sixel: move sixel_parser_parse() and add missing sequences and blocks

### DIFF
--- a/sixel.c
+++ b/sixel.c
@@ -36,7 +36,11 @@ static sixel_color_t const sixel_default_color_table[] = {
 void
 scroll_images(int n) {
 	ImageList *im, *next;
+	#if SCROLLBACK_PATCH
 	int top = tisaltscr() ? 0 : term.scr - HISTSIZE;
+	#else
+	int top = 0;
+	#endif // SCROLLBACK_PATCH
 
 	for (im = term.images; im; im = next) {
 		next = im->next;

--- a/st.h
+++ b/st.h
@@ -80,7 +80,6 @@ typedef struct _ImageList {
 	int height;
 	int x;
 	int y;
-	int reflow_y;
 	int cols;
 	int cw;
 	int ch;

--- a/x.c
+++ b/x.c
@@ -3092,7 +3092,11 @@ xfinishdraw(void)
 		width = MIN(width, (x2 - im->x) * win.cw);
 
 		/* delete the image if the text cells behind it have been changed */
+		#if SCROLLBACK_PATCH
 		line = TLINE(im->y);
+		#else
+		line = term.line[im->y];
+		#endif // SCROLLBACK_PATCH
 		for (del = 0, x = im->x; x < x2; x++) {
 			if ((del = !(line[x].mode & ATTR_SIXEL)))
 				break;


### PR DESCRIPTION
Changes:

- Move sixel_parser_parse() from tputc() to twrite()
- Add missing 8452, DECSDM, XTSMGRAPHICS and XTWINOPS sequences
- Add more conditional blocks for the scrollback and sync patches
- Remove unused reflow_y from ImageList. It is only used for the scrollback-reflow patch in st-sx.