### PR TITLE
osc133: initial patch implementation

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -467,6 +467,10 @@ static Shortcut shortcuts[] = {
 	#if INVERT_PATCH
 	{ TERMMOD,              XK_X,           invert,          { 0 } },
 	#endif // INVERT_PATCH
+	#if OSC133_PATCH
+	{ TERMMOD,              XK_Z,           scrolltoprompt,  {.i = -1}, S_PRI },
+	{ TERMMOD,              XK_X,           scrolltoprompt,  {.i =  1}, S_PRI },
+	#endif // OSC133_PATCH
 };
 
 /*

--- a/patch/osc133.c
+++ b/patch/osc133.c
@@ -1,0 +1,23 @@
+void scrolltoprompt(const Arg *arg) {
+	int x, y;
+	int top = term.scr - term.histf;
+	int bot = term.scr + term.row-1;
+	int dy = arg->i;
+	Line line;
+
+	if (!dy || tisaltscr())
+		return;
+
+	for (y = dy; y >= top && y <= bot; y += dy) {
+		for (line = TLINE(y), x = 0; x < term.col; x++) {
+			if (line[x].mode & ATTR_FTCS_PROMPT)
+				goto scroll;
+		}
+	}
+
+scroll:
+	if (dy < 0)
+		kscrollup(&((Arg){ .i = -y }));
+	else
+		kscrolldown(&((Arg){ .i = y }));
+}

--- a/patch/osc133.c
+++ b/patch/osc133.c
@@ -1,6 +1,10 @@
 void scrolltoprompt(const Arg *arg) {
 	int x, y;
+	#if REFLOW_PATCH
 	int top = term.scr - term.histf;
+	#else
+	int top = term.scr - term.histn;
+	#endif // REFLOW_PATCH
 	int bot = term.scr + term.row-1;
 	int dy = arg->i;
 	Line line;

--- a/patch/osc133.h
+++ b/patch/osc133.h
@@ -1,0 +1,1 @@
+static void scrolltoprompt(const Arg *);

--- a/patch/x_include.c
+++ b/patch/x_include.c
@@ -47,3 +47,6 @@
 #if XRESOURCES_PATCH
 #include "xresources.c"
 #endif
+#if OSC133_PATCH
+#include "osc133.c"
+#endif

--- a/patch/x_include.h
+++ b/patch/x_include.h
@@ -43,4 +43,4 @@
 #endif
 #if OSC133_PATCH
 #include "osc133.h"
-#endif // OSC133_PATCH
+#endif

--- a/patch/x_include.h
+++ b/patch/x_include.h
@@ -41,3 +41,6 @@
 #if XRESOURCES_PATCH
 #include "xresources.h"
 #endif
+#if OSC133_PATCH
+#include "osc133.h"
+#endif // OSC133_PATCH

--- a/patches.def.h
+++ b/patches.def.h
@@ -302,7 +302,7 @@
 #define OPENURLONCLICK_PATCH 0
 
 /* This patch allows jumping between prompts by utilizing the OSC 133 escape sequence
- * emitted by shells.
+ * emitted by shells. Must be used with either reflow or scrollback patch.
  *
  * https://codeberg.org/dnkl/foot#jumping-between-prompts
  */

--- a/patches.def.h
+++ b/patches.def.h
@@ -301,6 +301,13 @@
  */
 #define OPENURLONCLICK_PATCH 0
 
+/* This patch allows jumping between prompts by utilizing the OSC 133 escape sequence
+ * emitted by shells.
+ *
+ * https://codeberg.org/dnkl/foot#jumping-between-prompts
+ */
+#define OSC133_PATCH 0
+
 /* Reflow.
  * Allows st to be resized without cutting off text when the terminal window is made larger again.
  * Text wraps when the terminal window is made smaller.

--- a/st.c
+++ b/st.c
@@ -2699,6 +2699,25 @@ strhandle(void)
 				tfulldirt();
 			}
 			return;
+		#if OSC133_PATCH
+		case 133:
+			if (narg < 2)
+				break;
+			switch (*strescseq.args[1]) {
+			case 'A':
+				term.c.attr.mode |= ATTR_FTCS_PROMPT;
+				break;
+			/* We don't handle these arguments yet */
+			case 'B':
+			case 'C':
+			case 'D':
+				break;
+			default:
+				fprintf(stderr, "erresc: unknown OSC 133 argument: %c\n", *strescseq.args[1]);
+				break;
+			}
+			return;
+		#endif // OSC133_PATCH
 		}
 		break;
 	case 'k': /* old title set compatibility */
@@ -3449,6 +3468,9 @@ check_control_code:
 	}
 
 	tsetchar(u, &term.c.attr, term.c.x, term.c.y);
+	#if OSC133_PATCH
+	term.c.attr.mode &= ~ATTR_FTCS_PROMPT;
+	#endif // OSC133_PATCH
 	term.lastc = u;
 
 	if (width == 2) {

--- a/st.h
+++ b/st.h
@@ -70,6 +70,9 @@ enum glyph_attribute {
 	ATTR_HIGHLIGHT      = 1 << 17,
 	#endif // KEYBOARDSELECT_PATCH
 	ATTR_BOLD_FAINT = ATTR_BOLD | ATTR_FAINT,
+	#if OSC133_PATCH
+	ATTR_FTCS_PROMPT    = 1 << 18,  /* OSC 133 ; A ST */
+	#endif // OSC133_PATCH
 };
 
 #if SIXEL_PATCH


### PR DESCRIPTION
This patch introduces support for OSC133 as discussed in #126. It borrows veltza's st-sx implementation and introduces two new key bindings, `<ctrl+shift+z/x>` to scroll between prompts.