### PR TITLE
sixel: prevent crashing when size is zero

### DIFF
--- a/x.c
+++ b/x.c
@@ -3145,8 +3145,8 @@ xfinishdraw(void)
 			continue;
 
 		/* scale the image */
-		width = im->width * win.cw / im->cw;
-		height = im->height * win.ch / im->ch;
+		width = MAX(im->width * win.cw / im->cw, 1);
+		height = MAX(im->height * win.ch / im->ch, 1);
 		if (!im->pixmap) {
 			im->pixmap = (void *)XCreatePixmap(xw.dpy, xw.win, width, height,
 				#if ALPHA_PATCH


### PR DESCRIPTION
Crashing happens when you zoom out and the width or height of an image becomes zero.