### PR TITLE
sixel: add support for fully transparent bg (P2=1)

### DIFF
--- a/patch/reflow.c
+++ b/patch/reflow.c
@@ -81,7 +81,7 @@ treflow(int col, int row)
 	int oce, nce, bot, scr;
 	int ox = 0, oy = -term.histf, nx = 0, ny = -1, len;
 	int cy = -1; /* proxy for new y coordinate of cursor */
-	int buflen, nlines, del;
+	int buflen, nlines;
 	Line *buf, bufline, line;
 	#if SIXEL_PATCH
 	ImageList *im, *next;
@@ -219,21 +219,14 @@ treflow(int col, int row)
 		}
 	}
 
-	/* expand images into new text cells or
-	 * delete images if there is text behind them */
+	/* expand images into new text cells */
 	for (im = term.images; im; im = next) {
 		next = im->next;
 		if (im->x < col) {
 			line = TLINE(im->y);
 			x2 = MIN(im->x + im->cols, col);
-			for (del = 0, x = im->x; x < x2; x++) {
-				if ((del = line[x].mode & ATTR_SET))
-					break;
-				line[x].u = ' ';
-				line[x].mode = ATTR_SIXEL;
-			}
-			if (del)
-				delete_image(im);
+			for (x = im->x; x < x2; x++)
+				line[x].mode |= ATTR_SIXEL;
 		}
 	}
 	#endif // SIXEL_PATCH

--- a/sixel.h
+++ b/sixel.h
@@ -39,6 +39,7 @@ typedef struct parser_context {
 	int attributed_pad;
 	int attributed_ph;
 	int attributed_pv;
+	int transparent;
 	int repeat_count;
 	int color_index;
 	int bgindex;
@@ -52,10 +53,11 @@ typedef struct parser_context {
 
 void scroll_images(int n);
 void delete_image(ImageList *im);
-int sixel_parser_init(sixel_state_t *st, sixel_color_t fgcolor, sixel_color_t bgcolor, unsigned char use_private_register, int cell_width, int cell_height);
+int sixel_parser_init(sixel_state_t *st, int transparent, sixel_color_t fgcolor, sixel_color_t bgcolor, unsigned char use_private_register, int cell_width, int cell_height);
 int sixel_parser_parse(sixel_state_t *st, const unsigned char *p, size_t len);
 int sixel_parser_set_default_color(sixel_state_t *st);
 int sixel_parser_finalize(sixel_state_t *st, ImageList **newimages, int cx, int cy, int cw, int ch);
 void sixel_parser_deinit(sixel_state_t *st);
+Pixmap sixel_create_clipmask(char *pixels, int width, int height);
 
 #endif

--- a/st.h
+++ b/st.h
@@ -77,6 +77,7 @@ typedef struct _ImageList {
 	struct _ImageList *next, *prev;
 	unsigned char *pixels;
 	void *pixmap;
+	void *clipmask;
 	int width;
 	int height;
 	int x;
@@ -87,6 +88,7 @@ typedef struct _ImageList {
 	int cols;
 	int cw;
 	int ch;
+	int transparent;
 } ImageList;
 #endif // SIXEL_PATCH
 

--- a/x.c
+++ b/x.c
@@ -325,7 +325,10 @@ zoomabs(const Arg *arg)
 	for (im = term.images; im; im = im->next) {
 		if (im->pixmap)
 			XFreePixmap(xw.dpy, (Drawable)im->pixmap);
+		if (im->clipmask)
+			XFreePixmap(xw.dpy, (Drawable)im->clipmask);
 		im->pixmap = NULL;
+		im->clipmask = NULL;
 	}
 	#endif // SIXEL_PATCH
 
@@ -3138,7 +3141,7 @@ xfinishdraw(void)
 	XGCValues gcvalues;
 	GC gc;
 	int width, height;
-	int x, x2, del;
+	int x, x2, del, destx, desty;
 	Line line;
 	#endif // SIXEL_PATCH
 
@@ -3161,6 +3164,8 @@ xfinishdraw(void)
 				DefaultDepth(xw.dpy, xw.scr)
 				#endif // ALPHA_PATCH
 			);
+			if (!im->pixmap)
+				continue;
 			if (win.cw == im->cw && win.ch == im->ch) {
 				XImage ximage = {
 					.format = ZPixmap,
@@ -3181,12 +3186,15 @@ xfinishdraw(void)
 					#endif // ALPHA_PATCH
 				};
 				XPutImage(xw.dpy, (Drawable)im->pixmap, dc.gc, &ximage, 0, 0, 0, 0, width, height);
+				if (im->transparent)
+					im->clipmask = (void *)sixel_create_clipmask((char *)im->pixels, width, height);
 			} else {
 				origin = imlib_create_image_using_data(im->width, im->height, (DATA32 *)im->pixels);
 				if (!origin)
 					continue;
 				imlib_context_set_image(origin);
 				imlib_image_set_has_alpha(1);
+				imlib_context_set_anti_alias(im->transparent ? 0 : 1); /* anti-aliasing messes up the clip mask */
 				scaled = imlib_create_cropped_scaled_image(0, 0, im->width, im->height, width, height);
 				imlib_free_image_and_decache();
 				if (!scaled)
@@ -3212,6 +3220,8 @@ xfinishdraw(void)
 					#endif // ALPHA_PATCH
 				};
 				XPutImage(xw.dpy, (Drawable)im->pixmap, dc.gc, &ximage, 0, 0, 0, 0, width, height);
+				if (im->transparent)
+					im->clipmask = (void *)sixel_create_clipmask((char *)imlib_image_get_data_for_reading_only(), width, height);
 				imlib_free_image_and_decache();
 			}
 		}
@@ -3240,12 +3250,17 @@ xfinishdraw(void)
 		gcvalues.graphics_exposures = False;
 		gc = XCreateGC(xw.dpy, xw.win, GCGraphicsExposures, &gcvalues);
 		#if ANYSIZE_PATCH
-		XCopyArea(xw.dpy, (Drawable)im->pixmap, xw.buf, gc, 0, 0,
-			width, height, win.hborderpx + im->x * win.cw, win.vborderpx + im->y * win.ch);
+		destx = win.hborderpx + im->x * win.cw;
+		desty = win.vborderpx + im->y * win.ch;
 		#else
-		XCopyArea(xw.dpy, (Drawable)im->pixmap, xw.buf, gc, 0, 0,
-			width, height, borderpx + im->x * win.cw, borderpx + im->y * win.ch);
+		destx = borderpx + im->x * win.cw;
+		desty = borderpx + im->y * win.ch;
 		#endif // ANYSIZE_PATCH
+		if (im->clipmask) {
+			XSetClipMask(xw.dpy, gc, (Drawable)im->clipmask);
+			XSetClipOrigin(xw.dpy, gc, destx, desty);
+		}
+		XCopyArea(xw.dpy, (Drawable)im->pixmap, xw.buf, gc, 0, 0, width, height, destx, desty);
 		XFreeGC(xw.dpy, gc);
 	}
 	#endif // SIXEL_PATCH


### PR DESCRIPTION
P2 selects how the terminal draws the background color.

```
P2                  Meaning
0 or 2 (default)    Pixel positions specified as 0 are set to the
                    current background color.
1                   Pixel positions specified as 0 remain at their
                    current color.
```

Both modes are now supported.

Ref. https://www.vt100.net/docs/vt3xx-gp/chapter14.html