### PR TITLE
sixel: prevent drawing on search bar

### DIFF
--- a/x.c
+++ b/x.c
@@ -3178,6 +3178,12 @@ xfinishdraw(void)
 		if (im->x >= term.col || im->y >= term.row || im->y < 0)
 			continue;
 
+		#if KEYBOARDSELECT_PATCH && REFLOW_PATCH
+		/* do not draw the image on the search bar */
+		if (im->y == term.row-1 && IS_SET(MODE_KBDSELECT) && kbds_issearchmode())
+			continue;
+		#endif // KEYBOARDSELECT_PATCH
+
 		/* scale the image */
 		width = MAX(im->width * win.cw / im->cw, 1);
 		height = MAX(im->height * win.ch / im->ch, 1);


### PR DESCRIPTION
It's annoying to use the search bar when it's behind an image. So this fix prevents that from happening.