### PR TITLE
sixel: improve the renderer

### DIFF
--- a/patch/reflow.c
+++ b/patch/reflow.c
@@ -77,7 +77,7 @@ treflow_moveimages(int oldy, int newy)
 void
 treflow(int col, int row)
 {
-	int i, j, x, x2;
+	int i, j;
 	int oce, nce, bot, scr;
 	int ox = 0, oy = -term.histf, nx = 0, ny = -1, len;
 	int cy = -1; /* proxy for new y coordinate of cursor */
@@ -220,13 +220,12 @@ treflow(int col, int row)
 	}
 
 	/* expand images into new text cells */
-	for (im = term.images; im; im = next) {
-		next = im->next;
-		if (im->x < col) {
-			line = TLINE(im->y);
-			x2 = MIN(im->x + im->cols, col);
-			for (x = im->x; x < x2; x++)
-				line[x].mode |= ATTR_SIXEL;
+	for (im = term.images; im; im = im->next) {
+		j = MIN(im->x + im->cols, col);
+		line = TLINE(im->y);
+		for (i = im->x; i < j; i++) {
+			if (!(line[i].mode & ATTR_SET))
+				line[i].mode |= ATTR_SIXEL;
 		}
 	}
 	#endif // SIXEL_PATCH

--- a/x.c
+++ b/x.c
@@ -3167,9 +3167,14 @@ xfinishdraw(void)
 	ImageList *im, *next;
 	Imlib_Image origin, scaled;
 	XGCValues gcvalues;
-	GC gc;
+	GC gc = NULL;
 	int width, height;
-	int x, x2, del, destx, desty;
+	int del, desty, mode, x1, x2, xend;
+	#if ANYSIZE_PATCH
+	int bw = win.hborderpx, bh = win.vborderpx;
+	#else
+	int bw = borderpx, bh = borderpx;
+	#endif // ANYSIZE_PATCH
 	Line line;
 	#endif // SIXEL_PATCH
 
@@ -3260,43 +3265,50 @@ xfinishdraw(void)
 			}
 		}
 
-		/* clip the image so it does not go over to borders */
-		x2 = MIN(im->x + im->cols, term.col);
-		width = MIN(width, (x2 - im->x) * win.cw);
-
-		/* delete the image if the text cells behind it have been changed */
-		#if SCROLLBACK_PATCH || REFLOW_PATCH
-		line = TLINE(im->y);
-		#else
-		line = term.line[im->y];
-		#endif // SCROLLBACK_PATCH | REFLOW_PATCH
-		for (del = 0, x = im->x; x < x2; x++) {
-			if ((del = !(line[x].mode & ATTR_SIXEL)))
-				break;
-		}
-		if (del) {
-			delete_image(im);
-			continue;
+		/* create GC */
+		if (!gc) {
+			memset(&gcvalues, 0, sizeof(gcvalues));
+			gcvalues.graphics_exposures = False;
+			gc = XCreateGC(xw.dpy, xw.win, GCGraphicsExposures, &gcvalues);
 		}
 
-		/* draw the image */
-		memset(&gcvalues, 0, sizeof(gcvalues));
-		gcvalues.graphics_exposures = False;
-		gc = XCreateGC(xw.dpy, xw.win, GCGraphicsExposures, &gcvalues);
-		#if ANYSIZE_PATCH
-		destx = win.hborderpx + im->x * win.cw;
-		desty = win.vborderpx + im->y * win.ch;
-		#else
-		destx = borderpx + im->x * win.cw;
-		desty = borderpx + im->y * win.ch;
-		#endif // ANYSIZE_PATCH
+		/* set the clip mask */
+		desty = bh + im->y * win.ch;
 		if (im->clipmask) {
 			XSetClipMask(xw.dpy, gc, (Drawable)im->clipmask);
-			XSetClipOrigin(xw.dpy, gc, destx, desty);
+			XSetClipOrigin(xw.dpy, gc, bw + im->x * win.cw, desty);
 		}
-		XCopyArea(xw.dpy, (Drawable)im->pixmap, xw.buf, gc, 0, 0, width, height, destx, desty);
-		XFreeGC(xw.dpy, gc);
+
+		/* draw only the parts of the image that are not erased */
+		#if SCROLLBACK_PATCH || REFLOW_PATCH
+		line = TLINE(im->y) + im->x;
+		#else
+		line = term.line[im->y] + im->x;
+		#endif // SCROLLBACK_PATCH || REFLOW_PATCH
+		xend = MIN(im->x + im->cols, term.col);
+		for (del = 1, x1 = im->x; x1 < xend; x1 = x2) {
+			mode = line->mode & ATTR_SIXEL;
+			for (x2 = x1 + 1; x2 < xend; x2++) {
+				if (((++line)->mode & ATTR_SIXEL) != mode)
+					break;
+			}
+			if (mode) {
+				XCopyArea(xw.dpy, (Drawable)im->pixmap, xw.buf, gc,
+				    (x1 - im->x) * win.cw, 0,
+				    MIN((x2 - x1) * win.cw, width - (x1 - im->x) * win.cw), height,
+				    bw + x1 * win.cw, desty);
+				del = 0;
+			}
+		}
+		if (im->clipmask)
+			XSetClipMask(xw.dpy, gc, None);
+
+		/* if all the parts are erased, we can delete the entire image */
+		if (del && im->x + im->cols <= term.col)
+			delete_image(im);
 	}
+	if (gc)
+		XFreeGC(xw.dpy, gc);
 	#endif // SIXEL_PATCH
 
 	#if !SINGLE_DRAWABLE_BUFFER_PATCH


### PR DESCRIPTION
In the current implementation, when text is written over an image, we have to cut the entire text line out of the image, regardless of how long the text is. It doesn't look good, but it was a design choice for the following reasons:
1) To keep the sixel engine as fast as possible
2) Most applications do not write text on the images anyway

To bring the st terminal in line with other terminals that support sixels, I have now improved the sixel renderer so that the images can now have gaps, which allows the text to be printed inside the images. The changes should not affect performance in normal cases. Only when the renderer has to deal with the text there might be some performance hits depending on how many gaps there are in the images.