### PR TITLE
sixel: prevent images from piling up

### DIFF
--- a/sixel.c
+++ b/sixel.c
@@ -261,10 +261,10 @@ sixel_parser_finalize(sixel_state_t *st, ImageList **newimages, int cx, int cy, 
 	sixel_image_t *image = &st->image;
 	int x, y;
 	sixel_color_no_t *src;
-	sixel_color_t *dst;
-	int color;
+	sixel_color_t *dst, color;
 	int w, h;
 	int i, j, cols, numimages;
+	char trans;
 	ImageList *im, *next, *tail;
 
 	if (!image->data)
@@ -311,7 +311,6 @@ sixel_parser_finalize(sixel_state_t *st, ImageList **newimages, int cx, int cy, 
 			im->clipmask = NULL;
 			im->cw = cw;
 			im->ch = ch;
-			im->transparent = st->transparent;
 		}
 		if (!im || !im->pixels) {
 			for (im = *newimages; im; im = next) {
@@ -324,11 +323,15 @@ sixel_parser_finalize(sixel_state_t *st, ImageList **newimages, int cx, int cy, 
 			return -1;
 		}
 		dst = (sixel_color_t *)im->pixels;
-		for (j = 0; j < im->height && y < h; j++, y++) {
+		for (trans = 0, j = 0; j < im->height && y < h; j++, y++) {
 			src = st->image.data + image->width * y;
-			for (x = 0; x < w; x++)
-				*dst++ = st->image.palette[*src++];
+			for (x = 0; x < w; x++) {
+				color = st->image.palette[*src++];
+				trans |= (color == 0);
+				*dst++ = color;
+			}
 		}
+		im->transparent = (st->transparent && trans);
 	}
 
 	return numimages;


### PR DESCRIPTION
Old images are automatically deleted if a new image is spawned over them. This prevents them from piling up and choking the terminal when viewing animated gifs.

Now if you use the latest version of Chafa to view the gifs, it will set the transparency attribute (P2=1) to all sixel images regardless of whether they are transparent or not. This prevents the auto-delete from working because if the image is transparent, we can't delete any images behind it.

The solution is that since Chafa fills the animation frames with an opaque black background color, we treat the images as non-transparent if they don't have any transparent pixels. This keeps the auto-delete running with the new Chafa.

Although the solution works now, it may not be a long-term solution.