### PR TITLE
Do not interpret CSI ? u as DECRC

### DIFF
--- a/st.c
+++ b/st.c
@@ -2524,7 +2524,11 @@ csihandle(void)
 		break;
 	#endif // CSI_22_23_PATCH | SIXEL_PATCH
 	case 'u': /* DECRC -- Restore cursor position (ANSI.SYS) */
-		tcursor(CURSOR_LOAD);
+		if (csiescseq.priv) {
+			goto unknown;
+		} else {
+			tcursor(CURSOR_LOAD);
+		}
 		break;
 	case ' ':
 		switch (csiescseq.mode[1]) {


### PR DESCRIPTION
Apply fix from st repository, commit [98610fc](https://git.suckless.org/st/commit/98610fcd37f655d44586323dc86c1d013c2798ce.html)

---

The kitty keyboard protocol docs recommend CSI ? u to query support for that protocol, see https://sw.kovidgoyal.net/kitty/keyboard-protocol/

For better or worse, fish shell uses this query to work around bugs in other terminals triggered by requesting that protocol via CSI = 5 u.

Unfortunately, st interprets CSI ? u as DECRC (restore cursor position). reproduce with 'printf "\x1b[?u"; cat'.

fish could work around this by switching to the alternate screen before running this query; but that might cause tearing on terminals that don't support Synchronized Output. I'm not sure.

In the meantime, let's correct our parser.

This adds a redundant else-after-return, for consistency with the surrounding code.

ref. https://git.suckless.org/st/commit/98610fcd37f655d44586323dc86c1d013c2798ce.html