### PR TITLE
add line_snap_delimiter patch

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -72,6 +72,9 @@ static float chscale = 1.0;
  * More advanced example: L" `'\"()[]{}"
  */
 wchar_t *worddelimiters = L" ";
+#if LINESNAP_PATCH
+wchar_t *snap_line_delimiters = L"│";
+#endif
 
 #if KEYBOARDSELECT_PATCH && REFLOW_PATCH
 /* Word delimiters for short and long jumps in the keyboard select patch */

--- a/patches.def.h
+++ b/patches.def.h
@@ -251,6 +251,17 @@
  */
 #define LIGATURES_PATCH 0
 
+/* This patch adds support for snapping line selection to stop at specific
+ * delimiter characters. This is primarily useful in terminal multiplexers like
+ * tmux, where a triple-click (line snap) would otherwise select across all
+ * panes, which is usually not desired.
+ *
+ * This patch is incompatible with the REFLOW patch
+ *
+ * https://st.suckless.org/patches/line_snap_delimiter/
+ */
+#define LINESNAP_PATCH 0
+
 /* This patch makes st ignore terminal color attributes by forcing display of the default
  * foreground and background colors only - making for a monochrome look. Idea ref.
  * https://www.reddit.com/r/suckless/comments/ixbx6z/how_to_use_black_and_white_only_for_st/

--- a/st.h
+++ b/st.h
@@ -412,6 +412,9 @@ extern char *scroll;
 extern char *stty_args;
 extern char *vtiden;
 extern wchar_t *worddelimiters;
+#if LINESNAP_PATCH
+extern wchar_t *snap_line_delimiters;
+#endif // LINESNAP_PATCH
 #if KEYBOARDSELECT_PATCH && REFLOW_PATCH
 extern wchar_t *kbds_sdelim;
 extern wchar_t *kbds_ldelim;


### PR DESCRIPTION
As a tmux user, the [line_snap_delimiter patch](https://st.suckless.org/patches/line_snap_delimiter/) is quite useful to me.
I often shift+triple click some output of a file to get the whole line into my clipboard.
Unfortunately the selection goes beyond the pane borders.
Before the patch i had to zoom the particular pane -> select the line -> cancel the zoom.
Left: without patch Right: with linesnap
https://github.com/user-attachments/assets/2236fd6d-6f61-4325-a441-71902fa187a1

Note

- Does not work when dragging across multiple lines
- Incompatible with reflow patch