### PR TITLE
Add selectionbg-alpha patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Refer to [https://st.suckless.org/](https://st.suckless.org/) for details on the
 
 ### Changelog:
 
+2025-10-28 - Added the slectionbg-alpha patch
+
 2025-02-20 - Added the drag-n-drop and open-selected-text patches
 
 2024-05-31 - Added the anygeometry patch

--- a/patches.def.h
+++ b/patches.def.h
@@ -380,6 +380,12 @@
  */
 #define SELECTION_COLORS_PATCH 0
 
+/* This patch works with selectioncolors and alpha patches to make selection
+ * background color transparent.
+ * https://st.suckless.org/patches/selectionbg-alpha/
+ */
+#define SELECTIONBG_ALPHA_PATCH 0
+
 /* This is the single drawable buffer patch as outlined in the FAQ to get images
  * in w3m to display. While this patch does not break the alpha patch it images
  * are not shown in w3m if the alpha patch is applied.

--- a/x.c
+++ b/x.c
@@ -980,6 +980,11 @@ xloadalpha(void)
 	dc.col[defaultbg].color.alpha = (unsigned short)(0xffff * usedAlpha);
 	dc.col[defaultbg].pixel &= 0x00FFFFFF;
 	dc.col[defaultbg].pixel |= (unsigned char)(0xff * usedAlpha) << 24;
+	#if SELECTION_COLORS_PATCH && SELECTIONBG_ALPHA_PATCH
+	dc.col[selectionbg].color.alpha = (unsigned short)(0xffff * usedAlpha);
+	dc.col[selectionbg].pixel &= 0x00FFFFFF;
+	dc.col[selectionbg].pixel |= (unsigned char)(0xff * usedAlpha) << 24;
+	#endif // SELECTION_COLORS_PATCH && SELECTIONBG_ALPHA_PATCH
 }
 #endif // ALPHA_FOCUS_HIGHLIGHT_PATCH
 
@@ -1041,6 +1046,18 @@ xloadcols(void)
 	dc.col[defaultbg].color.red   *= alpha;
 	dc.col[defaultbg].color.green *= alpha;
 	dc.col[defaultbg].color.blue  *= alpha;
+	#if SELECTION_COLORS_PATCH && SELECTIONBG_ALPHA_PATCH
+	/* set alpha value of selbg color */
+	dc.col[selectionbg].color.alpha = (unsigned short)(0xffff * alpha);
+	dc.col[selectionbg].pixel &= 0x00FFFFFF;
+	dc.col[selectionbg].pixel |= (unsigned char)(0xff * alpha) << 24;
+	dc.col[selectionbg].color.red =
+		((unsigned short)(dc.col[selectionbg].color.red * alpha)) & 0xff00;
+	dc.col[selectionbg].color.green =
+		((unsigned short)(dc.col[selectionbg].color.green * alpha)) & 0xff00;
+	dc.col[selectionbg].color.blue =
+		((unsigned short)(dc.col[selectionbg].color.blue * alpha)) & 0xff00;
+	#endif // SELECTION_COLORS_PATCH && SELECTIONBG_ALPHA_PATCH
 	#endif // ALPHA_PATCH
 	loaded = 1;
 }


### PR DESCRIPTION
Adding patch [selectionbg-alpha](https://st.suckless.org/patches/selectionbg-alpha).

It would be interesting to also allow the selection bg and fg to be se on xresorces, but this should do for now to provide the upstream patch as it is.

This addresses the request on issue #189 