### PR TITLE
add xresources-xdefaults patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Refer to [https://st.suckless.org/](https://st.suckless.org/) for details on the
 
 ### Changelog:
 
+2026-01-08 - Added the xresources-xdefaults patch
+
 2025-10-28 - Added the selectionbg-alpha patch
 
 2025-02-20 - Added the drag-n-drop and open-selected-text patches

--- a/README.md
+++ b/README.md
@@ -342,3 +342,6 @@ Refer to [https://st.suckless.org/](https://st.suckless.org/) for details on the
    - [xresources](https://st.suckless.org/patches/xresources/)
       - adds the ability to configure st via Xresources
       - during startup, st will read and apply the resources named in the resources[] array in config.h
+
+   - xresources-xdefaults
+      - allows .Xdefaults to be read as well in addition to the RESOURCE_MANAGER property on the root window

--- a/patch/xresources.c
+++ b/patch/xresources.c
@@ -36,6 +36,7 @@ resource_load(XrmDatabase db, char *name, enum resource_type rtype, void *dst)
 }
 
 #if XRESOURCES_XDEFAULTS_PATCH
+/* Returns an XrmDatabase that needs to be freed by the caller. */
 static XrmDatabase
 get_resources(Display *dpy)
 {
@@ -47,12 +48,7 @@ get_resources(Display *dpy)
 
 	char *displayResource, *xe;
 	XrmDatabase rdb1;
-	static XrmDatabase database = 0;
-
-	if (database)
-		XrmDestroyDatabase(database);
-
-	database = XrmGetStringDatabase("");
+	XrmDatabase database = XrmGetStringDatabase("");
 
 	/* For ordering, see for example http://www.faqs.org/faqs/Xt-FAQ/ Subject: 20 */
 
@@ -78,51 +74,6 @@ get_resources(Display *dpy)
 			XrmMergeDatabases(rdb1, &database);
 	}
 
-#if 0 /* This code would be needed if reload_config did not reopen the display each time. */
-
-	/* Get any Xserver Resources (xrdb). */
-	static int reloading = -1;
-	if (++reloading)
-	{
-		/* Urxvt's work-around for Xlib keeping a copy of the XResourceManagerString. */
-
-		Atom actual_type;
-		int actual_format;
-		unsigned long nitems, nremaining;
-		char *val = 0;
-
-		if (XGetWindowProperty(dpy, RootWindow(dpy, 0), XA_RESOURCE_MANAGER,
-					0L, 100000000L, False,
-					XA_STRING, &actual_type, &actual_format,
-					&nitems, &nremaining,
-					(unsigned char **)&val) == Success
-				&& actual_type == XA_STRING
-				&& actual_format == 8)
-			displayResource = val;
-		else
-		{
-			displayResource = 0;
-
-			if (val)
-				XFree(val);
-		}
-	}
-	else
-		displayResource = XResourceManagerString(dpy);
-
-	if (displayResource)
-	{
-		if ((rdb1 = XrmGetStringDatabase(displayResource)))
-			XrmMergeDatabases(rdb1, &database);
-	}
-
-	if (reloading && displayResource)
-		XFree(displayResource);
-
-#else  /* This block assumes reload_config reopens the display each time.
-	* Code is free from memory leaks (valgrind).
-	*/
-
 	/* Get any Xserver Resources (xrdb). */
 	displayResource = XResourceManagerString(dpy);
 
@@ -131,7 +82,6 @@ get_resources(Display *dpy)
 		if ((rdb1 = XrmGetStringDatabase(displayResource)))
 			XrmMergeDatabases(rdb1, &database);
 	}
-#endif
 
 	/* Get screen specific resources. */
 	displayResource = XScreenResourceString(ScreenOfDisplay(dpy, DefaultScreen(dpy)));
@@ -146,8 +96,7 @@ get_resources(Display *dpy)
 
 	/* 3. User's per host defaults file. */
 	/* Add in XENVIRONMENT file */
-	if ((xe = getenv("XENVIRONMENT"))
-			&& (rdb1 = XrmGetFileDatabase(xe)))
+	if ((xe = getenv("XENVIRONMENT")) && (rdb1 = XrmGetFileDatabase(xe)))
 		XrmMergeDatabases(rdb1, &database);
 	else if (homedir)
 	{
@@ -164,20 +113,33 @@ get_resources(Display *dpy)
 
 	return database;
 }
-#endif //XRESOURCES_XDEFAULTS_PATCH
 
 void
 config_init(Display *dpy)
 {
-	#if !XRESOURCES_XDEFAULTS_PATCH
+	XrmDatabase db;
+	ResourcePref *p;
+
+	XrmInitialize();
+	db = get_resources(dpy);
+
+	for (p = resources; p < resources + LEN(resources); p++)
+		resource_load(db, p->name, p->type, p->dst);
+
+	XrmDestroyDatabase(db);
+}
+
+#else // !XRESOURCES_XDEFAULTS_PATCH
+
+void
+config_init(Display *dpy)
+{
 	char *resm;
-	#endif // XRESOURCES_XDEFAULTS_PATCH
 	XrmDatabase db;
 	ResourcePref *p;
 
 	XrmInitialize();
 
-	#if !XRESOURCES_XDEFAULTS_PATCH
 	resm = XResourceManagerString(dpy);
 	if (!resm)
 		return;
@@ -185,15 +147,13 @@ config_init(Display *dpy)
 	db = XrmGetStringDatabase(resm);
 	if (!db)
 		return;
-	#else
-	db = get_resources(dpy);
-	#endif // XRESOURCES_XDEFAULTS_PATCH
 
 	for (p = resources; p < resources + LEN(resources); p++)
 		resource_load(db, p->name, p->type, p->dst);
 
 	XrmDestroyDatabase(db);
 }
+#endif // XRESOURCES_XDEFAULTS_PATCH
 
 #if XRESOURCES_RELOAD_PATCH
 void

--- a/patch/xresources.h
+++ b/patch/xresources.h
@@ -1,7 +1,7 @@
 #include <X11/Xresource.h>
 #if XRESOURCES_XDEFAULTS_PATCH
 #include <sys/utsname.h>
-#endif //XRESOURCES_XDEFAULTS_PATCH
+#endif // XRESOURCES_XDEFAULTS_PATCH
 
 /* Xresources preferences */
 enum resource_type {

--- a/patch/xresources.h
+++ b/patch/xresources.h
@@ -1,4 +1,7 @@
 #include <X11/Xresource.h>
+#if XRESOURCES_XDEFAULTS_PATCH
+#include <sys/utsname.h>
+#endif //XRESOURCES_XDEFAULTS_PATCH
 
 /* Xresources preferences */
 enum resource_type {

--- a/patches.def.h
+++ b/patches.def.h
@@ -535,3 +535,10 @@
  * Depends on the XRESOURCES_PATCH.
  */
 #define XRESOURCES_RELOAD_PATCH 0
+
+/* This patch adds the ability to configure st via Xdefaults, in addition to Xresources,
+ * like the rxvt-unicode terminal. At startup, st will read and apply the system and user's
+ * local Xdefault files, the XServer's Xresources, and the screen and per-host Xdefaults.
+ * This patch depends on XRESOURCES_PATCH and is compatible with XRESOURCES_RELOAD_PATCH.
+ */
+#define XRESOURCES_XDEFAULTS_PATCH 0


### PR DESCRIPTION
This patch adds the ability to configure st via Xdefaults, in addition to Xresources, like the rxvt-unicode terminal. At startup, st will read and apply the system and user's local Xdefault files, the XServer's Xresources, and the screen and per-host Xdefaults. This patch depends on XRESOURCES_PATCH and is compatible with XRESOURCES_RELOAD_PATCH.

I used the following script to stress test this patch. You can also use the script to demo what the patch does. To be simple, it only tests the user's .Xdefaults and .Xresources files, without throwing in the system and per-host files. The script cycles st's background through red, green and blue indefinitely.

BACKUP YOUR ~/.Xdefaults and ~/.Xresources FILES BEFORE TESTING.

```sh

unset pid
if [ -n "$1" ]; then
	pid=$1
elif pid=$(pgrep -f ^valgrind) && [ -n "$pid" ]; then
	:
else
	pid=$(pgrep -n ^st$)
fi
if [ -z "$pid" -o "x$pid" = "x-h" -o "x$pid" = "x--help" ]; then
	echo "usage: $0 [pid]
	If pid is omitted valgrind's is used falling back to st's.
	---------------------------------------------------------------
	BACKUP YOUR ~/.Xdefaults and ~/.Xresources FILES BEFORE TESTING
	---------------------------------------------------------------"
	exit 0
fi
printf "Attaching pid=%d\n\t%s\n" "$pid" "$(ps -h -ocmd "$pid")" >&2

seconds=0.25 red='#800000' green='#008000' blue='#000080'
echo "St.background: $red" >> $HOME/.Xdefaults
while true; do
	sed -i "\$s/$red/$green/" $HOME/.Xdefaults
	kill -USR1 $pid
	sleep $seconds
	sed -i "\$s/$green/$red/" $HOME/.Xdefaults
	kill -USR1 $pid
	sleep $seconds

	echo "St.background: $blue" >> $HOME/.Xresources
	xrdb -load $HOME/.Xresources
	kill -USR1 $pid
	sleep $seconds
	sed -i '$d' $HOME/.Xresources
	xrdb -load $HOME/.Xresources
	kill -USR1 $pid
	sleep $seconds
done
```