### PR TITLE
Remove useless flag for cp to install st.desktop file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ install: st
 	chmod 644 $(DESTDIR)$(MANPREFIX)/man1/st.1
 	tic -sx st.info
 	mkdir -p $(DESTDIR)$(PREFIX)/share/applications # desktop-entry patch
-	test -f ${DESTDIR}${PREFIX}/share/applications/st.desktop || cp -n st.desktop $(DESTDIR)$(PREFIX)/share/applications # desktop-entry patch
+	test -f ${DESTDIR}${PREFIX}/share/applications/st.desktop || cp st.desktop $(DESTDIR)$(PREFIX)/share/applications # desktop-entry patch
 	@echo Please see the README file regarding the terminfo entry of st.
 
 uninstall:


### PR DESCRIPTION
`-n` flag used to copy `st.desktop` file during install, is not supported by `cp` command on OpenBSD.

Fix #204